### PR TITLE
Add config option for multipart upload chunk size

### DIFF
--- a/aptrust-bagit.py
+++ b/aptrust-bagit.py
@@ -133,11 +133,12 @@ def generate_aptrust_info(bag_path, title, access='consortia'):
 def push_to_aptrust(tarred_bag, env='test', verbose=False):
     tar_base_name = os.path.split(tarred_bag)[1]
     s3 = boto3.resource('s3')
+    s3_config = boto3.s3.transfer.TransferConfig(multipart_chunksize=config['multipart_chunksize'])
 
     if verbose:
-        s3.meta.client.upload_file(tarred_bag, config[env]['receiving_bucket'], tar_base_name, Callback=ProgressPercentage(tarred_bag))
+        s3.meta.client.upload_file(tarred_bag, config[env]['receiving_bucket'], tar_base_name, Callback=ProgressPercentage(tarred_bag), Config=s3_config)
     else:
-        s3.meta.client.upload_file(tarred_bag, config[env]['receiving_bucket'], tar_base_name)
+        s3.meta.client.upload_file(tarred_bag, config[env]['receiving_bucket'], tar_base_name, Config=s3_config)
 
     return tar_base_name
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -11,6 +11,9 @@ institution: 'somewhere'
 # Max bag size (in bytes)
 multi_threshold: 1234567890
 
+# Chunk size of each multipart upload to S3 (in bytes)
+multipart_chunksize: 8388608
+
 # Test APTrust/S3 server credentials
 test:
   receiving_bucket: 'aptrust.receiving.test.somewhere.edu'


### PR DESCRIPTION
File transfers to S3 are divided into chunks and reassembled after
upload. S3 accepts a maximum of 10,000 chunks, and boto3 sets the
default chunk size to 8MB, for a maximum upload size of ~80GB.
Increasing the multipart_chunksize allows for larger uploads.